### PR TITLE
Allow creating key from a value

### DIFF
--- a/flask_api_key/api_key.py
+++ b/flask_api_key/api_key.py
@@ -149,6 +149,20 @@ class APIKey(object):
 
         self.hashed_key = self._hash(self.full_key)
 
+    def gen_key_from_value(self, label, value):
+        """62 character charset has 5.95 entropy per character
+           64 character secret has ~380 bits entropy
+        """
+
+        uuid = uuid4()
+
+        self.label = label
+        self.uuid = uuid.hex
+        self.friendly_uuid = str(uuid)
+        self._secret = value
+
+        self.hashed_key = self._hash(self.full_key)
+
     @property
     def full_key(self):
         """If we have all the pieces, construct the full_key.  Only

--- a/flask_api_key/api_key_manager.py
+++ b/flask_api_key/api_key_manager.py
@@ -16,7 +16,6 @@ from .api_key import APIKey
 
 
 class APIKeyManager(object):
-
     POSSIBLE_LOCATIONS = ['header']
 
     def __init__(self, app=None):
@@ -68,6 +67,7 @@ class APIKeyManager(object):
         """Simple method to register a default errorhandler.  Mainly
         a placeholder for potentially more handlers in the future.
         """
+
         @app.errorhandler(APIKeyError)
         def handle_api_key_error(e):
             return self._error_handler_callback(e)
@@ -257,4 +257,25 @@ class APIKeyManager(object):
 
         ak = APIKey()
         ak.gen_key(label)
+        return self._create_api_key_callback(ak.export())
+
+    def create_from_value(self, label, value):
+        """Using this wrapper is the recommended way to import your apikeys.
+
+        Attr:
+            label - required.  Simple label for the key.
+            value - required.  Key value to create from.
+
+        -EXAMPLE USAGE-
+
+        mgr = get_apikey_manager()
+        my_key = mgr.create_from_value('MY_SECURE_APIKEY', 'MY_API_KEY')
+
+        # Optionally
+        my_key.my_other_attribute = 'foo'
+        my_key.save()
+        """
+
+        ak = APIKey()
+        ak.gen_key_from_value(label, value)
         return self._create_api_key_callback(ak.export())


### PR DESCRIPTION
One would need to import a predefined value of the API key to the middleware instead of creating a random key. This allows management of API keys independently from the API itself